### PR TITLE
Add architecture and delivery phase documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # my-rss
+
+A cross-platform RSS reader with semantic article grouping, source aggregation, and expiration-based feed management.
+
+## Vision
+
+Most RSS readers track every article individually. This reader groups similar stories from different sources into a single cluster — one tap marks all coverage of a topic as read. Stories expire automatically, keeping your feed clean without manual triage.
+
+## Platforms
+
+| Platform | Stack | Status |
+|---|---|---|
+| Web | Next.js, Firebase Auth, Firestore | Phase 1 — in progress |
+| iOS | Swift, SwiftUI, Firebase SDK | Phase 4 |
+| Android | Kotlin, Compose, Firebase SDK | Phase 4 |
+
+## Key Features
+
+- **Semantic article grouping** — articles covering the same story are clustered together across sources
+- **Mark cluster as read** — reading one story marks all coverage of it as read
+- **Article expiration** — breaking news expires in 24–48h; features last longer; configurable per feed
+- **Social sources** — connect Reddit and Substack accounts alongside standard RSS feeds
+- **Cross-platform sync** — account, subscriptions, and read state sync via Firestore
+
+## Architecture
+
+See [`docs/architecture.md`](docs/architecture.md) for the full system design.
+
+## Development
+
+See [`docs/phases.md`](docs/phases.md) for the phased delivery plan.
+
+### Quick start (web)
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+Requires environment variables — see [`web/.env.example`](web/.env.example) once scaffolded.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,142 @@
+# Architecture
+
+## Infrastructure (GCP)
+
+| Service | Role |
+|---|---|
+| Firebase Auth | Identity — shared across web, iOS, Android |
+| Cloud Firestore | Primary database — users, feeds, clusters, read state |
+| Cloud Run | Stateless API + background services |
+| Cloud Scheduler | Triggers periodic feed fetch jobs |
+| Cloud Pub/Sub | Decouples feed fetcher from article processor |
+| Vertex AI (text-embedding-004) | Semantic embeddings for article grouping |
+| Firebase Hosting | Serves the Next.js web app |
+
+## Services
+
+```
+┌──────────────────┐     Cloud Scheduler (every 15 min)
+│  Feed Fetcher    │◄────────────────────────────────────
+│  (Cloud Run)     │
+│                  │  fetches RSS, Reddit, Substack
+└────────┬─────────┘
+         │ publishes raw articles
+         ▼
+    [Pub/Sub topic: raw-articles]
+         │
+         ▼
+┌──────────────────┐
+│Article Processor │  - normalizes articles
+│  (Cloud Run)     │  - computes text embeddings (Vertex AI)
+│                  │  - finds or creates cluster
+│                  │  - sets expiresAt
+└────────┬─────────┘
+         │ writes
+         ▼
+    [Cloud Firestore]
+         │
+         ▼
+┌──────────────────┐
+│   API Service    │  REST, authenticated via Firebase Auth
+│  (Cloud Run)     │  consumed by web + mobile clients
+└──────────────────┘
+```
+
+## Data Model
+
+### `users/{uid}`
+```
+{
+  email: string,
+  displayName: string,
+  createdAt: timestamp,
+  settings: {
+    defaultExpiryHours: number   // default: 48
+  }
+}
+```
+
+### `users/{uid}/feeds/{feedId}`
+```
+{
+  type: "rss" | "reddit" | "substack",
+  url: string,                   // RSS URL or account identifier
+  title: string,
+  expiryHours: number | null,    // null = use user default
+  addedAt: timestamp,
+  lastFetchedAt: timestamp
+}
+```
+
+### `articles/{articleId}`
+```
+{
+  feedId: string,
+  uid: string,                   // owner user
+  sourceUrl: string,
+  title: string,
+  body: string,
+  author: string | null,
+  publishedAt: timestamp,
+  expiresAt: timestamp,
+  clusterId: string | null,
+  embeddingVector: number[],     // stored for similarity lookup
+  source: string                 // human-readable source name
+}
+```
+
+### `clusters/{clusterId}`
+```
+{
+  uid: string,
+  topic: string,                 // derived label (most common headline words)
+  articleIds: string[],
+  sources: string[],             // list of source names
+  firstSeenAt: timestamp,
+  latestAt: timestamp,
+  expiresAt: timestamp,
+  centroidVector: number[]       // mean of member article embeddings
+}
+```
+
+### `users/{uid}/readClusters/{clusterId}`
+```
+{
+  readAt: timestamp
+}
+```
+
+## Article Grouping Logic
+
+1. New article arrives from processor.
+2. Compute text embedding via Vertex AI `text-embedding-004`.
+3. Load all non-expired clusters for this user created within a configurable time window (default: 48h).
+4. Compute cosine similarity between article embedding and each cluster's `centroidVector`.
+5. If similarity ≥ threshold (default: 0.85), add article to that cluster and update centroid.
+6. Otherwise, create a new cluster with this article as the seed.
+7. Set `expiresAt` on the article and cluster based on feed's `expiryHours`.
+
+## Article Expiration
+
+- Each article and cluster has an `expiresAt` timestamp.
+- The API filters out expired clusters from responses by default.
+- A nightly Cloud Scheduler job hard-deletes documents older than 30 days to control storage costs.
+- Expiry defaults: breaking news feeds = 48h, feature/magazine feeds = 7d, user-configurable per feed.
+
+## Authentication Flow
+
+- Firebase Auth handles sign-in (Google OAuth initially; email/password and Apple ID in later phases).
+- Web: Firebase client SDK manages tokens; API service verifies via Firebase Admin SDK.
+- Mobile: Firebase SDK handles token refresh natively.
+
+## Social Source Integration
+
+### Reddit
+- User authenticates via Reddit OAuth2.
+- Feed fetcher uses Reddit API to pull subscribed subreddits and home feed.
+- Posts normalized into the standard article schema.
+- Rate limits: 60 requests/minute per OAuth token.
+
+### Substack
+- Most Substack publications expose standard RSS feeds — no auth required for free content.
+- OAuth integration for paywalled content is a future stretch goal.

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -1,0 +1,93 @@
+# Delivery Phases
+
+## Phase 1 — Web MVP (target: 2–3 weeks)
+
+**Goal:** Deployed web app where users can sign in, add RSS feeds, and read grouped articles.
+
+### Scope
+- [ ] Firebase Auth (Google sign-in)
+- [ ] Add, list, and delete RSS feed subscriptions
+- [ ] Cloud Scheduler → Cloud Run feed fetcher → Pub/Sub pipeline
+- [ ] Article processor with naive title-similarity grouping (normalized title hashing; no ML yet)
+- [ ] Expiration logic (default 48h, configurable per feed)
+- [ ] Read state written to Firestore, synced in real time
+- [ ] Next.js web UI
+  - [ ] Sign in / sign out
+  - [ ] Feed management screen
+  - [ ] Clustered article list (unread by default)
+  - [ ] Article detail / open original
+  - [ ] Mark cluster as read
+- [ ] Deploy to Firebase Hosting + Cloud Run
+
+### Out of scope for Phase 1
+- Semantic ML grouping
+- Reddit / Substack
+- Mobile apps
+
+---
+
+## Phase 2 — Smart Grouping + Polish (target: 2 weeks)
+
+**Goal:** Replace naive grouping with semantic embeddings; improve UX.
+
+### Scope
+- [ ] Integrate Vertex AI `text-embedding-004` in the article processor
+- [ ] Cluster centroid management in Firestore
+- [ ] Cluster topic label derivation
+- [ ] Per-feed expiry settings in the UI
+- [ ] PWA manifest + basic offline support
+- [ ] Performance and loading state polish
+
+---
+
+## Phase 3 — Social Sources (target: 2–3 weeks)
+
+**Goal:** Connect Reddit and Substack alongside RSS.
+
+### Scope
+- [ ] Reddit OAuth2 flow in the web app
+- [ ] Reddit feed fetcher (subscribed subreddits + home feed)
+- [ ] Substack RSS auto-detection from publication URL
+- [ ] Source badges in cluster view (show which outlets covered a story)
+- [ ] Account linking UI (connect/disconnect Reddit)
+
+---
+
+## Phase 4 — iOS (target: 4–6 weeks)
+
+**Goal:** Native iOS app with feature parity to web.
+
+### Scope
+- [ ] Harden Cloud Run API (versioned REST, documented contracts)
+- [ ] Swift package with shared API client
+- [ ] SwiftUI app: feed list, cluster reader, settings
+- [ ] Firebase Auth (Google + Apple sign-in)
+- [ ] Firestore real-time listeners
+- [ ] FCM push notifications for high-priority clusters
+- [ ] App Store submission
+
+---
+
+## Phase 5 — Android (target: 4–6 weeks, can overlap with Phase 4)
+
+**Goal:** Native Android app with feature parity to web.
+
+### Scope
+- [ ] Kotlin + Compose app: feed list, cluster reader, settings
+- [ ] Firebase Auth (Google sign-in)
+- [ ] Firestore SDK
+- [ ] FCM push notifications
+- [ ] Play Store submission
+
+---
+
+## Open Questions
+
+| Question | Default assumption | Needs decision |
+|---|---|---|
+| Similarity threshold for grouping | 0.85 cosine similarity | Tune in Phase 2 |
+| Default expiry window | 48h news, 7d features | Yes — expose as user setting |
+| Auth providers at launch | Google only | Email/password too? |
+| Substack paywalled content | RSS only (free posts) | OAuth stretch goal |
+| Feed fetch frequency | Every 15 minutes | May need per-feed overrides |
+| Hard-delete retention | 30 days post-expiry | Confirm with storage cost targets |


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the my-rss project, including system architecture, data model, and a phased delivery plan. It also updates the README with project vision and quick-start instructions.

## Key Changes

- **`docs/architecture.md`** — Complete system design covering:
  - GCP infrastructure stack (Firebase Auth, Firestore, Cloud Run, Pub/Sub, Vertex AI)
  - Service architecture diagram (feed fetcher → processor → API)
  - Data model schemas for users, feeds, articles, and clusters
  - Article grouping logic using semantic embeddings
  - Expiration and cleanup strategy
  - Authentication and social source integration details

- **`docs/phases.md`** — Five-phase delivery roadmap:
  - Phase 1: Web MVP with RSS feeds and naive grouping (2–3 weeks)
  - Phase 2: Semantic ML grouping with Vertex AI (2 weeks)
  - Phase 3: Reddit and Substack integration (2–3 weeks)
  - Phase 4: iOS native app (4–6 weeks)
  - Phase 5: Android native app (4–6 weeks)
  - Includes open questions and decision points

- **`README.md`** — Updated with:
  - Project vision and core value proposition
  - Platform and feature overview
  - Links to architecture and phase documentation
  - Quick-start instructions for local web development

## Implementation Details

The documentation establishes:
- A clear separation of concerns across Cloud Run services (fetcher, processor, API)
- Pub/Sub as the decoupling mechanism between feed ingestion and processing
- Cosine similarity (threshold 0.85) for semantic clustering via Vertex AI embeddings
- Configurable expiration windows (default 48h for news, 7d for features)
- Real-time sync via Firestore for cross-platform consistency

This provides the foundation for team alignment and phased execution.

https://claude.ai/code/session_01NtBVexRtrvQcJXx7ruiGsv