### PR TITLE
Fix feed-fetcher to find feeds without a parent user document

### DIFF
--- a/services/article-processor/package-lock.json
+++ b/services/article-processor/package-lock.json
@@ -8,6 +8,7 @@
       "name": "article-processor",
       "version": "0.1.0",
       "dependencies": {
+        "dotenv": "^17.4.2",
         "express": "^4.19.0",
         "firebase-admin": "^12.3.0"
       },
@@ -967,6 +968,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/services/article-processor/package.json
+++ b/services/article-processor/package.json
@@ -8,13 +8,14 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
+    "dotenv": "^17.4.2",
     "express": "^4.19.0",
     "firebase-admin": "^12.3.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.0",
     "@types/node": "^20.14.0",
-    "typescript": "^5.5.0",
-    "ts-node": "^10.9.0"
+    "ts-node": "^10.9.0",
+    "typescript": "^5.5.0"
   }
 }

--- a/services/article-processor/src/index.ts
+++ b/services/article-processor/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import express from 'express'
 import { initializeApp } from 'firebase-admin/app'
 import { getFirestore, Timestamp, FieldValue } from 'firebase-admin/firestore'

--- a/services/feed-fetcher/package-lock.json
+++ b/services/feed-fetcher/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@google-cloud/pubsub": "^4.5.0",
+        "dotenv": "^17.4.2",
         "express": "^4.19.0",
         "firebase-admin": "^12.3.0",
         "rss-parser": "^3.13.0"
@@ -976,6 +977,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/services/feed-fetcher/package.json
+++ b/services/feed-fetcher/package.json
@@ -8,15 +8,16 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "express": "^4.19.0",
-    "rss-parser": "^3.13.0",
     "@google-cloud/pubsub": "^4.5.0",
-    "firebase-admin": "^12.3.0"
+    "dotenv": "^17.4.2",
+    "express": "^4.19.0",
+    "firebase-admin": "^12.3.0",
+    "rss-parser": "^3.13.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.0",
     "@types/node": "^20.14.0",
-    "typescript": "^5.5.0",
-    "ts-node": "^10.9.0"
+    "ts-node": "^10.9.0",
+    "typescript": "^5.5.0"
   }
 }

--- a/services/feed-fetcher/src/index.ts
+++ b/services/feed-fetcher/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import express from 'express'
 import Parser from 'rss-parser'
 import { initializeApp } from 'firebase-admin/app'
@@ -26,14 +27,11 @@ app.post('/fetch', async (_req, res) => {
   let published = 0
 
   try {
-    const usersSnap = await db.collection('users').get()
+    const feedsSnap = await db.collectionGroup('feeds').get()
     const topic = PROCESSOR_URL ? null : pubsub.topic(TOPIC)
 
-    for (const userDoc of usersSnap.docs) {
-      const uid = userDoc.id
-      const feedsSnap = await db.collection('users').doc(uid).collection('feeds').get()
-
-      for (const feedDoc of feedsSnap.docs) {
+    for (const feedDoc of feedsSnap.docs) {
+      const uid = feedDoc.ref.parent.parent!.id
         const feed = feedDoc.data()
         if (feed.type !== 'rss') continue
 
@@ -79,7 +77,6 @@ app.post('/fetch', async (_req, res) => {
           errors.push(`feed ${feedDoc.id}: ${err}`)
           console.error(`Error fetching feed ${feedDoc.id}:`, err)
         }
-      }
     }
 
     res.json({ published, errors })


### PR DESCRIPTION
## Summary

- Switches from `db.collection('users').get()` to `db.collectionGroup('feeds').get()` — the user document at `users/{uid}` is never explicitly created, only the `feeds` subcollection, so the old query always returned 0 results and nothing was ever published
- Adds `dotenv` to both services so `.env` is loaded in local dev

## Test plan

- [ ] Start article-processor and feed-fetcher locally
- [ ] `curl -X POST http://localhost:8081/fetch` returns `published > 0`
- [ ] Stories appear in reader after fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)