### PR TITLE
Add build step to functions deploy workflow

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -32,5 +32,9 @@ jobs:
         working-directory: functions
         run: npm ci
 
+      - name: Build
+        working-directory: functions
+        run: npm run build
+
       - name: Deploy functions
         run: firebase deploy --only functions --project ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
## Summary

Firebase CLI requires `dist/index.js` to exist before deploying. Added a `npm run build` step to compile TypeScript before `firebase deploy`.

## Test plan
- [ ] Workflow runs and function deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)