### PR TITLE
Add workflow_dispatch to functions deploy workflow

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths: ['functions/**', 'firebase.json']
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` so the functions deploy can be triggered manually — needed since workflow file changes don't match the paths filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)