### PR TITLE
Fix TypeScript build errors in functions

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@types/xml2js": "^0.4.14",
         "typescript": "^5.5.0"
       },
       "engines": {
@@ -554,6 +555,16 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT"
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/xml2js": "^0.4.14",
     "typescript": "^5.5.0"
   }
 }

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "esModuleInterop": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "outDir": "dist",


### PR DESCRIPTION
## Summary

- Add `esModuleInterop: true` to tsconfig to fix `rss-parser` default import
- Add `@types/xml2js` dev dependency to resolve implicit `any` on xml2js (transitive dep of rss-parser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)