### PR TITLE
Add --force to firebase deploy for cleanup policy

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -38,4 +38,4 @@ jobs:
         run: npm run build
 
       - name: Deploy functions
-        run: firebase deploy --only functions --project ${{ secrets.GCP_PROJECT_ID }}
+        run: firebase deploy --only functions --project ${{ secrets.GCP_PROJECT_ID }} --force


### PR DESCRIPTION
## Summary

The function deploys successfully but `firebase deploy` exits with code 1 when no Artifact Registry cleanup policy is configured. `--force` sets the policy automatically, keeping the 10 most recent container images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)