### PR TITLE
Add CLAUDE.md and update docs to reflect current state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+Guidelines for working with Claude Code in this repo.
+
+## Git workflow
+
+- **Never push directly to `main`.** Always create a branch, open a PR, and let the human merge.
+- Branch naming: `feature/`, `fix/`, `docs/` prefixes.
+- Commit `package-lock.json` alongside `package.json` whenever dependencies change — `npm ci` in Docker requires it.
+
+## Node
+
+- Node 22 (LTS) is used across all services and the Cloud Function.
+- nvm is used locally. Source it before running node commands: `. $NVM_DIR/nvm.sh`
+
+## Local development
+
+### Services
+
+Each service has a `.env` file (copied from `.env.example`) for local config. dotenv is loaded automatically via `import 'dotenv/config'` at the top of each service entry point.
+
+```bash
+# article-processor (port 8082)
+cd services/article-processor && npm run dev
+
+# feed-fetcher (port 8081) — posts directly to article-processor locally
+cd services/feed-fetcher && npm run dev
+
+# trigger a fetch
+curl -X POST http://localhost:8081/fetch
+```
+
+### Web
+
+```bash
+cd web && npm run dev
+```
+
+Requires a `.env.local` with the `NEXT_PUBLIC_FIREBASE_*` values from Firebase Console.
+
+## Deploying
+
+All deployments happen via GitHub Actions on merge to `main`. There is no manual deploy process.
+
+| Service | Workflow | Trigger |
+|---|---|---|
+| `web` | `deploy-web.yml` | changes to `web/**` |
+| `feed-fetcher` | `deploy-feed-fetcher.yml` | changes to `services/feed-fetcher/**` |
+| `article-processor` | `deploy-article-processor.yml` | changes to `services/article-processor/**` |
+| `onFeedAdded` function | `deploy-functions.yml` | changes to `functions/**` or `firebase.json` |
+
+The functions workflow also has `workflow_dispatch` for manual triggering via the GitHub Actions UI or `gh workflow run deploy-functions.yml`.
+
+## Firebase / Firestore
+
+- Firestore security rules live in `firestore.rules`. Deploy them via the Firebase Rules REST API or Firebase CLI (`firebase deploy --only firestore:rules`).
+- The `users/{uid}` document is **never explicitly created** — only the `users/{uid}/feeds/{feedId}` subcollection is written. Any query that needs all feeds must use `db.collectionGroup('feeds')`.
+
+## Structured logging
+
+`feed-fetcher` emits structured JSON logs to stdout, which Cloud Run forwards to Cloud Logging. Log events:
+
+| Event | Key fields |
+|---|---|
+| `fetch_started` | `feedCount` |
+| `feed_fetched` | `feedId`, `feedTitle`, `articlesPublished` |
+| `feed_fetch_error` | `feedId`, `feedTitle`, `error` |
+| `fetch_complete` | `totalPublished`, `totalErrors`, `durationMs` |
+| `fetch_fatal` | `error`, `durationMs` |
+
+Query in Log Explorer:
+```
+resource.type="cloud_run_revision"
+resource.labels.service_name="feed-fetcher"
+jsonPayload.event="feed_fetch_error"
+```
+
+## GCP project
+
+- Project ID: `my-rss-prod`
+- Region: `us-central1`
+- Firestore: `nam5` (multi-region)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,33 +2,33 @@
 
 ## Infrastructure (GCP)
 
-| Service | Role |
-|---|---|
-| Firebase Auth | Identity — shared across web, iOS, Android |
-| Cloud Firestore | Primary database — users, feeds, clusters, read state |
-| Cloud Run | Stateless API + background services |
-| Cloud Scheduler | Triggers periodic feed fetch jobs |
-| Cloud Pub/Sub | Decouples feed fetcher from article processor |
-| Vertex AI (text-embedding-004) | Semantic embeddings for article grouping |
-| Firebase Hosting | Serves the Next.js web app |
+| Service | Role | Status |
+|---|---|---|
+| Firebase Auth | Identity — shared across web, iOS, Android | Live |
+| Cloud Firestore | Primary database — users, feeds, clusters, read state | Live |
+| Cloud Run | Stateless services (web, feed-fetcher, article-processor) | Live |
+| Cloud Scheduler | Triggers periodic feed fetch every 15 min | Live |
+| Cloud Pub/Sub | Decouples feed fetcher from article processor | Live |
+| Cloud Functions | Event-driven triggers (e.g. onFeedAdded) | Live |
+| Vertex AI (text-embedding-004) | Semantic embeddings for article grouping | Planned |
+| Firebase Hosting | Serves the Next.js web app | Not used (web on Cloud Run) |
 
 ## Services
 
 ```
 ┌──────────────────┐     Cloud Scheduler (every 15 min)
 │  Feed Fetcher    │◄────────────────────────────────────
-│  (Cloud Run)     │
-│                  │  fetches RSS, Reddit, Substack
-└────────┬─────────┘
+│  (Cloud Run)     │◄────────────────────────────────────── onFeedAdded
+│                  │  fetches RSS feeds                     (Cloud Function,
+└────────┬─────────┘                                        Firestore trigger)
          │ publishes raw articles
          ▼
     [Pub/Sub topic: raw-articles]
-         │
+         │ (push subscription)
          ▼
 ┌──────────────────┐
-│Article Processor │  - normalizes articles
-│  (Cloud Run)     │  - computes text embeddings (Vertex AI)
-│                  │  - finds or creates cluster
+│Article Processor │  - deduplicates by URL
+│  (Cloud Run)     │  - clusters by Jaccard title similarity
 │                  │  - sets expiresAt
 └────────┬─────────┘
          │ writes
@@ -37,10 +37,17 @@
          │
          ▼
 ┌──────────────────┐
-│   API Service    │  REST, authenticated via Firebase Auth
-│  (Cloud Run)     │  consumed by web + mobile clients
+│   Web (Next.js)  │  authenticated via Firebase Auth
+│  (Cloud Run)     │  reads clusters + articles directly from Firestore
 └──────────────────┘
 ```
+
+## Key implementation notes
+
+- **Clustering** uses Jaccard similarity on stopword-filtered title tokens (no embeddings yet). Threshold: 0.3.
+- **Feed fetcher** queries feeds via `db.collectionGroup('feeds')` — the parent `users/{uid}` document is never explicitly created, only the subcollection.
+- **onFeedAdded** fires on `users/{uid}/feeds/{feedId}` document creation, fetches the new feed immediately, and publishes articles to Pub/Sub — articles appear within seconds of adding a feed rather than waiting up to 15 min for the scheduler.
+- **Pub/Sub push** delivers to article-processor at its Cloud Run URL, authenticated via `pubsub-push-sa` with `roles/run.invoker`.
 
 ## Data Model
 
@@ -108,13 +115,18 @@
 
 ## Article Grouping Logic
 
-1. New article arrives from processor.
-2. Compute text embedding via Vertex AI `text-embedding-004`.
-3. Load all non-expired clusters for this user created within a configurable time window (default: 48h).
-4. Compute cosine similarity between article embedding and each cluster's `centroidVector`.
-5. If similarity ≥ threshold (default: 0.85), add article to that cluster and update centroid.
-6. Otherwise, create a new cluster with this article as the seed.
-7. Set `expiresAt` on the article and cluster based on feed's `expiryHours`.
+Current implementation (Jaccard similarity):
+
+1. New article arrives via Pub/Sub push to article-processor.
+2. Deduplicate by `sourceUrl` — skip if already stored.
+3. Load all non-expired clusters for this user within the expiry window.
+4. Tokenize article title (lowercase, strip punctuation, remove stopwords).
+5. Compute Jaccard similarity between article tokens and each cluster's `topic` tokens.
+6. If best score ≥ 0.3, merge article into that cluster.
+7. Otherwise, create a new cluster seeded by this article's title.
+8. Set `expiresAt` on article and cluster based on feed's `expiryHours` (default: 48h).
+
+Planned upgrade: replace Jaccard with Vertex AI `text-embedding-004` cosine similarity for better semantic matching across paraphrased headlines.
 
 ## Article Expiration
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,16 +1,22 @@
 # CI/CD — GitHub Actions + GCP
 
-Three workflows deploy each service independently when their files change on `main`:
+Four workflows deploy each service independently when their files change on `main`:
 
-| Workflow | Trigger path | Cloud Run service |
+| Workflow | Trigger path | Deploys |
 |---|---|---|
-| `deploy-web.yml` | `web/**` | `web` |
-| `deploy-feed-fetcher.yml` | `services/feed-fetcher/**` | `feed-fetcher` |
-| `deploy-article-processor.yml` | `services/article-processor/**` | `article-processor` |
+| `deploy-web.yml` | `web/**` | Cloud Run: `web` |
+| `deploy-feed-fetcher.yml` | `services/feed-fetcher/**` | Cloud Run: `feed-fetcher` |
+| `deploy-article-processor.yml` | `services/article-processor/**` | Cloud Run: `article-processor` |
+| `deploy-functions.yml` | `functions/**`, `firebase.json` | Cloud Function: `onFeedAdded` |
 
-Images are tagged with the Git SHA and `latest`, pushed to Artifact Registry, then deployed to Cloud Run.
+Cloud Run images are tagged with the Git SHA and `latest`, pushed to Artifact Registry, then deployed. The functions workflow uses Firebase CLI to deploy.
 
 Auth uses **Workload Identity Federation** — no service account key files are stored anywhere.
+
+The functions workflow also supports `workflow_dispatch` for manual triggering:
+```bash
+gh workflow run deploy-functions.yml --repo joshuatphelps/my-rss --ref main
+```
 
 ---
 
@@ -41,7 +47,7 @@ gcloud iam workload-identity-pools providers create-oidc github-provider \
 gcloud iam service-accounts create github-actions-sa \
   --display-name="GitHub Actions CI/CD"
 
-# 4. Grant it the minimum roles needed to build and deploy
+# 4. Grant all roles needed to build, deploy, and manage functions
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:github-actions-sa@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/run.admin"
@@ -50,18 +56,50 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:github-actions-sa@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/artifactregistry.writer"
 
-# Needed so the SA can assign service accounts to Cloud Run services at deploy time
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:github-actions-sa@$PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/iam.serviceAccountUser"
 
-# 5. Allow the GitHub repo to impersonate the SA
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:github-actions-sa@$PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/cloudfunctions.developer"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:github-actions-sa@$PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/firebase.admin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:github-actions-sa@$PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/serviceusage.serviceUsageAdmin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:github-actions-sa@$PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/resourcemanager.projectIamAdmin"
+
+# 5. Grant the compute service account the Eventarc receiver role (required for Firestore-triggered functions)
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+  --role="roles/eventarc.eventReceiver"
+
+# 6. Grant the Eventarc service agent its role
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-eventarc.iam.gserviceaccount.com" \
+  --role="roles/eventarc.serviceAgent"
+
+# 7. Enable required APIs
+gcloud services enable \
+  cloudfunctions.googleapis.com \
+  cloudbuild.googleapis.com \
+  eventarc.googleapis.com \
+  cloudbilling.googleapis.com
+
+# 8. Allow the GitHub repo to impersonate the SA
 gcloud iam service-accounts add-iam-policy-binding \
   github-actions-sa@$PROJECT_ID.iam.gserviceaccount.com \
   --member="principalSet://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/github-pool/attribute.repository/$REPO" \
   --role="roles/iam.workloadIdentityUser"
 
-# 6. Print the values you'll need for GitHub secrets
+# 9. Print the values you'll need for GitHub secrets
 echo ""
 echo "--- GitHub Secrets ---"
 echo "WIF_PROVIDER: projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
@@ -77,8 +115,8 @@ Go to **github.com/joshuatphelps/my-rss → Settings → Secrets and variables �
 
 | Secret | Value |
 |---|---|
-| `WIF_PROVIDER` | Output from step 6 above |
-| `WIF_SERVICE_ACCOUNT` | Output from step 6 above |
+| `WIF_PROVIDER` | Output from step 9 above |
+| `WIF_SERVICE_ACCOUNT` | Output from step 9 above |
 | `GCP_PROJECT_ID` | `my-rss-prod` |
 | `NEXT_PUBLIC_FIREBASE_API_KEY` | From Firebase Console |
 | `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | From Firebase Console |
@@ -88,3 +126,19 @@ Go to **github.com/joshuatphelps/my-rss → Settings → Secrets and variables �
 | `NEXT_PUBLIC_FIREBASE_APP_ID` | From Firebase Console |
 
 Firebase config values are in **Firebase Console → Project Settings → Your apps → Web app → SDK setup and configuration**.
+
+> **Note:** Firebase secrets must be repository secrets (not environment secrets) — they are baked into the Next.js Docker image at build time via `--build-arg`.
+
+---
+
+## Firebase setup
+
+Firestore security rules and indexes are in `firestore.rules` and `firestore.indexes.json`. Deploy them with:
+
+```bash
+firebase deploy --only firestore:rules,firestore:indexes --project my-rss-prod
+```
+
+Firebase Auth requires:
+- **Google** sign-in provider enabled (Firebase Console → Authentication → Sign-in method)
+- The Cloud Run web service URL added to authorized domains (Firebase Console → Authentication → Settings → Authorized domains)


### PR DESCRIPTION
## Summary

Documents everything from this session so future work starts with full context.

**CLAUDE.md** (new):
- No direct pushes to main — always branch + PR
- Local dev setup for all services
- Firestore collectionGroup gotcha
- Structured logging event reference

**docs/ci-cd.md** (updated):
- Added functions deploy workflow
- All IAM roles required (several were missing and caused deploy failures)
- Firebase secrets must be repository secrets, not environment secrets
- Firebase Auth and Firestore rules setup steps

**docs/architecture.md** (updated):
- Added status column (live vs. planned) to infrastructure table
- Diagram updated to show onFeedAdded Cloud Function and actual web setup
- Article grouping section updated to describe actual Jaccard implementation vs. planned Vertex AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)